### PR TITLE
일반 ESLint 규칙 예외 정리

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ module.exports = {
     // 클래스 메서드 안에서 반드시 this를 사용할 필요 없음
     'class-methods-use-this': 'off',
 
-    // 행의 최대 길이는 140
-    'max-len': ['warn', 140],
+    // 행의 최대 길이는 120
+    'max-len': ['warn', 120],
 
     // 문장의 마지막에 존재하는 주석 시작 전에 한 개 이상의 공백을 허용
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: 'airbnb',
   rules: {
     // 프로퍼티 이름은 camelCase를 강제하지 않음
+    // 참고: https://github.com/ridi/style-guide/blob/master/API.md#user-content-http-api-작성-가이드
     camelcase: ['error', { properties: 'never' }],
 
     // 클래스 메서드 안에서 반드시 this를 사용할 필요 없음

--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
 module.exports = {
   extends: 'airbnb',
   rules: {
+    // 프로퍼티 이름은 camelCase를 강제하지 않음
+    'camelcase': ['error', { 'properties': 'never' }],
+
+    // 클래스 메서드 안에서 반드시 this를 사용할 필요 없음
+    'class-methods-use-this': 'off',
+
+    // 행의 최대 길이는 140
+    'max-len': ['warn', 140],
+
+    // 문장의 마지막에 존재하는 주석 시작 전에 한 개 이상의 공백을 허용
+    'no-multi-spaces': ['error', { ignoreEOLComments: true }],
   },
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: 'airbnb',
   rules: {
     // 프로퍼티 이름은 camelCase를 강제하지 않음
-    'camelcase': ['error', { 'properties': 'never' }],
+    camelcase: ['error', { properties: 'never' }],
 
     // 클래스 메서드 안에서 반드시 this를 사용할 필요 없음
     'class-methods-use-this': 'off',


### PR DESCRIPTION
이전에 쓰던 룰 중에서 꼭 필요하다고 생각되는 것만 남겨봤습니다.
제거되어도 상관 없거나 더 추가되어야 할 룰이 있다면 여기서 논의해보면 좋을 것 같습니다.

### 다시 추가된 예외들
* `camelcase`: API 응답의 프로퍼티들이 모두 snake_case로 통용되기 때문에 일부 값들의 경우에 일시적으로라도 snake_case를 사용해야 하는 경우가 있습니다. 그래서 프로퍼티에 한해서 예외를 두도록 하였습니다.
* `class-methods-use-this`: 클래스 메서드 안에서 반드시 this를 사용하는 것으로 강제하는 것은 너무 과도한 제약이라고 생각했습니다.
* `max-len`: airbnb 기본 설정이 100자로 되어 있는데, 현재 사용하는 모니터 크기에 비해 턱없이 적은 글자수인 것 같습니다. 120/140자가 좋을 것 같습니다.
* `no-multi-spaces`: 코멘트의 줄을 맞추는 것은 가독성을 위해 중요할 때가 있습니다. 물론 statement 중간에 다중 공백이 포함되는 것은 막아야겠지만, 라인의 마지막에 존재하는 코멘트들 앞의 공백까지 막을 필요는 없을 것 같습니다.

### 제거해도 괜찮다고 생각하는 예외들

* `no-param-reassign`: airbnb의 예외를 따름(https://github.com/airbnb/javascript/blob/90235cab7c060d69430001cf17aa28ff74da86b4/packages/eslint-config-airbnb-base/rules/best-practices.js#L172)
* `import/extensions`: airbnb의 예외를 따름(https://github.com/airbnb/javascript/blob/ea8fd76c5e17abd8597baf981ad32a3ec21c48dd/packages/eslint-config-airbnb-base/rules/imports.js#L19)
* `comma-dangle`, `no-underscore-dangle`: 강제하더라도 크게 문제 없을 것 같습니다.
* `no-constant-condition`: airbnb의 예외를 따름(https://github.com/airbnb/javascript/blob/7ff6303513b46e8b7dd0bc03327b138a6db7b3b4/packages/eslint-config-airbnb-base/rules/errors.js#L26)
* `no-plusplus`: airbnb에서 설명한 것처럼 `a++`보다는 `a += 1`을 사용하는 것이 안전할 것 같습니다. (https://github.com/airbnb/javascript/blob/aefff97bd10e8e17963749bd1013a6927d90fe29/README.md#variables--unary-increment-decrement)
* `valid-jsdoc`: airbnb에서는 jsdoc을 강제하고 있지 않은데, 굳이 따로 강제할 필요성을 느끼지 못했습니다.
* `import/no-unresolved`: 로컬 파일 시스템에 import한 모듈이 실제로 존재하는지를 체크하는 룰인데, 보통 
모듈 인스톨을 위해 node를 활용하는 npm, yarn을 사용하므로 airbnb의 룰을 따르면 될 것 같습니다.(https://github.com/airbnb/javascript/blob/ea8fd76c5e17abd8597baf981ad32a3ec21c48dd/packages/eslint-config-airbnb-base/rules/imports.js#L37)
* `import/no-extraneous-dependencies`: airbnb 룰에 추가되어서 따로 정의할 필요가 없어졌습니다.