### PR TITLE
Update dependencies

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,7 +1,7 @@
 module.exports = {
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   plugins: [
-    'babel',
+    '@babel',
   ],
   rules: {
     'babel/new-cap': 'warn',

--- a/package.json
+++ b/package.json
@@ -30,28 +30,36 @@
   },
   "homepage": "https://github.com/ridi/eslint-config#readme",
   "dependencies": {
-    "@typescript-eslint/parser": "^4.11.0",
-    "babel-eslint": "^10.1.0",
-    "eslint": "^7.16.0",
-    "eslint-config-airbnb": "^18.2.1",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^7.1.0"
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.5.0"
   },
-  "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.11.0",
-    "eslint-config-airbnb-typescript": "^12.0.0",
-    "eslint-plugin-babel": "^5.3.1",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-prettier": "^3.3.0",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.2.1",
+  "devDpendencies": {
+    "@babel/eslint-parser": "^7.17.7",
+    "@babel/eslint-plugin": "^7.17.7",
+    "@typescript-eslint/eslint-plugin": "^5.30.7",
+    "@typescript-eslint/parser": "^5.30.7",
+    "eslint": "^7.2.0 || ^8.20.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^2.7.1",
     "react": "^17.0.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-    "eslint-plugin-import": "^2.22.1"
+    "@babel/eslint-parser": "^7.17.7",
+    "@babel/eslint-plugin": "^7.17.7",
+    "@typescript-eslint/eslint-plugin": "^5.30.7",
+    "@typescript-eslint/parser": "^5.30.7",
+    "eslint": "^7.2.0 || ^8.20.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react-hooks": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/eslint-config",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "RIDI's ESLint configs for Javascript",
   "main": "index.js",
   "files": [

--- a/prettier.js
+++ b/prettier.js
@@ -1,9 +1,6 @@
 module.exports = {
   extends: [
     'prettier',
-    'prettier/@typescript-eslint',
-    'prettier/babel',
-    'prettier/react',
   ],
   parserOptions: {
     ecmaFeatures: {

--- a/react.js
+++ b/react.js
@@ -14,5 +14,12 @@ module.exports = {
     'react/jsx-filename-extension': ['error', {
       extensions: ['.jsx', '.tsx'],
     }],
+    'react/function-component-definition': ['warn', {
+      namedComponents: 'arrow-function',
+      unnamedComponents: 'arrow-function',
+    }],
+    'react/jsx-no-useless-fragment': ['warn', {
+      allowExpressions: true,
+    }],
   },
 };


### PR DESCRIPTION
* dependencies를 devDependencies와 peerDependencies로 옮겼습니다.
  * 특히 `@typescript/parser` 의 경우에는 프로젝트의 타입스크립트 버전과 묶여있기 때문에 디펜던시에 명시되지 않는 것이 나을 것이라 판단하였습니다.
  * `typescript>=4` 가 설치된 환경에서 작동하지 않는 이슈를 수정하였습니다.

* react에 룰을 추가하였습니다.
  * `react/jsx-no-useless-fragment` 와 `react/function-component-definition` 는 `eslint-plugin-react` 에 새로 도입된 룰입니다.
  * `prefer-arrow-callback` 이 prettier 룰에 정의돼있기 때문에 컴포넌트 정의 또한 HoC에서 사용할 때와 일관성을 유지하게 화살표 함수를 사용하게끔 했습니다.
  * 타입스크립트에서 사용 상의 편의를 위해 `react/jsx-no-useless-fragment` 에서 `allowExpression` 을 추가하였습니다.

* 기존과 호환성이 많이 깨짐에 따라 버전을 6으로 올렸습니다.