### PR TITLE
[web] ESLint 공용 설정 PeerDeps 범위 늘리기, DevDeps 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,15 +51,15 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@babel/eslint-parser": "^7.17.7",
-    "@babel/eslint-plugin": "^7.17.7",
-    "@typescript-eslint/eslint-plugin": "^5.30.7",
-    "@typescript-eslint/parser": "^5.30.7",
-    "eslint": "^7.2.0 || ^8.20.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsx-a11y": "^6.6.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "@babel/eslint-parser": ">=7.17.7",
+    "@babel/eslint-plugin": ">=7.17.7",
+    "@typescript-eslint/eslint-plugin": ">=5.30.7",
+    "@typescript-eslint/parser": ">=5.30.7",
+    "eslint": ">=7.2.0",
+    "eslint-plugin-import": ">=2.26.0",
+    "eslint-plugin-jsx-a11y": ">=6.6.0",
+    "eslint-plugin-prettier": ">=4.2.1",
+    "eslint-plugin-react": ">=7.30.1",
+    "eslint-plugin-react-hooks": ">=4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,21 +35,6 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0"
   },
-  "devDpendencies": {
-    "@babel/eslint-parser": "^7.17.7",
-    "@babel/eslint-plugin": "^7.17.7",
-    "@typescript-eslint/eslint-plugin": "^5.30.7",
-    "@typescript-eslint/parser": "^5.30.7",
-    "eslint": "^7.2.0 || ^8.20.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsx-a11y": "^6.6.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "prettier": "^2.7.1",
-    "react": "^17.0.1",
-    "typescript": "^4.7.4"
-  },
   "peerDependencies": {
     "@babel/eslint-parser": ">=7.17.7",
     "@babel/eslint-plugin": ">=7.17.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/eslint-config",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "RIDI's ESLint configs for Javascript",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## 문제
* `eslint-typescript` 가 `typescript@5` 와 호환되지 않습니다.
* 이는 `@ridi/eslint-config` 의 devDeps 가 같이 설치되는 이슈로, devDeps 안에 명시된 `@typescript-eslint/eslint-plugin` 이 작동하기 때문입니다.

## 해결
* devDeps 를 제거합니다.
* 또한 peerDeps 의 범위가 너무 좁게 명시된 문제가 있어 이 또한 수정합니다.